### PR TITLE
Add type annotation parsing for variables.

### DIFF
--- a/mrpython/type_annotation_parser.py
+++ b/mrpython/type_annotation_parser.py
@@ -1,0 +1,64 @@
+from popparser import Grammar, parsers, tokens
+from popparser.llparser import LLParsing
+from popparser.tokenizer import Tokenizer
+
+class TypeAnnotation:
+    def __init__(self, name, kind):
+        self.name = name
+        self.type = kind
+
+class TypeAnnotationParser:
+    def __init__(self):
+      self.grammar = Grammar()
+      self.forge_grammar(self.grammar)
+
+    def forge_tokenizer(self, tokenizer):
+
+        # punctuation
+        tokenizer.add_rule(tokens.Char('octothorpe', '#'))
+        tokenizer.add_rule(tokens.Char('colon', ':'))
+
+        # spaces
+        tokenizer.add_rule(tokens.CharSet('space', ' ', '\t', '\r'))
+
+        # identifiers
+        tokenizer.add_rule(tokens.Regexp('identifier',
+                                             "[a-zA-Z_][a-zA-Z_0-9]*'*"))
+        return tokenizer
+
+    def forge_grammar(self, grammar):
+
+        spaces_parser = parsers.Repeat(parsers.Token('space'), minimum=1)
+        grammar.register('spaces', spaces_parser)
+
+        grammar.register('colon', parsers.Token('colon'))
+        grammar.register('octothorpe', parsers.Token('octothorpe'))
+        grammar.register('identifier', parsers.Token('identifier'))
+        parser = parsers.Tuple().skip(grammar.ref('spaces'))\
+                                .skip(grammar.ref('octothorpe'))\
+                                .skip(grammar.ref('spaces'))\
+                                .element(grammar.ref('identifier'))\
+                                .skip(grammar.ref('spaces'))\
+                                .skip(grammar.ref('colon'))\
+                                .skip(grammar.ref('spaces'))\
+                                .element(grammar.ref('identifier'))
+
+        # Get a minimally structured result
+        def type_annot_xform(result):
+            name = result.content[0]
+            kind = result.content[1]
+            return TypeAnnotation(name.content.value, kind.content.value)
+
+        parser.xform_content = type_annot_xform
+
+        grammar.register('type_annot', parser)
+
+        grammar.entry = grammar.ref('type_annot')
+
+    def parse_from_string(self, string):
+        tokenizer = Tokenizer()
+        self.forge_tokenizer(tokenizer)
+        parser = LLParsing(self.grammar)
+        parser.tokenizer = tokenizer
+        tokenizer.from_string(string)
+        return parser.parse()

--- a/mrpython/typer.py
+++ b/mrpython/typer.py
@@ -1,0 +1,34 @@
+import ast
+from type_annotation_parser import TypeAnnotationParser
+
+class AssignAggregator(ast.NodeVisitor):
+    def __init__(self):
+        self.assigns = []
+
+    def visit_Assign(self, node):
+        self.assigns.append(node)
+
+def get_annotations(filename):
+    file = open(filename)
+    # Build a list of all lines for easy access to specific line
+    code = file.readlines()
+    # Get back to start of file for ast parsing
+    file.seek(0)
+    walker = AssignAggregator()
+    walker.visit(ast.parse(file.read()))
+    type_annotation_lines = [code[node.lineno - 2] for node in walker.assigns]
+    return type_annotation_lines
+
+def build_type_dict(type_annotation_lines):
+    ''' Use a popparser to parse type annotations'''
+    type_dict = {}
+    parser = TypeAnnotationParser()
+    parse_results = [parser.parse_from_string(code)\
+                        for code in type_annotation_lines]
+
+    for result in parse_results:
+        # Note that we reject every ill-formed annotation in the
+        # process of removing non-annotation lines.
+        if not result.iserror:
+            type_dict[result.content.id] = result.content.type
+    return type_dict


### PR DESCRIPTION
The parser currently doesn't retain any metadata.
It also can't really give a specific warning for missing
type annotation.