### PR TITLE
Add first pass at effect system

### DIFF
--- a/examples/list_add.py
+++ b/examples/list_add.py
@@ -1,0 +1,17 @@
+def original(l):
+    ''' Appends something to l'''
+    print(type(l))
+    l.append(1)
+    return l
+
+print(type(original([])))
+# def changed(l):
+#     # recurse on each element of list
+#     if l is list:
+#         l = ListWrapper(l)
+#         l[:] = map(ListWrapper.wrap_list, l)
+#         l = ListWrapper(l)
+#     l.append(1)
+#     # Add before each return
+#     l = list(l)
+#     return l

--- a/mrpython/effects/ListWrapper.py
+++ b/mrpython/effects/ListWrapper.py
@@ -1,0 +1,22 @@
+class ListWrapper(list):
+    def __init__(self, var=[]):
+        var[:] = map(ListWrapper.wrap, var)
+        super().__init__(var)
+
+    def append(self, elt):
+        print("Warning => Mutating List")
+        super().append(elt)
+
+    @staticmethod
+    def unwrap(var):
+        if isinstance(var, ListWrapper):
+            var[:] = map(ListWrapper.unwrap, var)
+            var = list(var)
+        return var
+
+    @staticmethod
+    def wrap(var):
+        if isinstance(var, list):
+            return ListWrapper(var)
+        else:
+            return var

--- a/mrpython/effects/effectVisitor.py
+++ b/mrpython/effects/effectVisitor.py
@@ -1,0 +1,53 @@
+import ast
+import astor
+
+def wrap_node(var_id):
+    code = "{0} = ListWrapper.wrap({0})".format(var_id)
+    return ast.parse(code)
+
+def unwrap_node(var_id):
+    code  = "ListWrapper.unwrap({0})".format(var_id)
+    return ast.parse(code)
+
+class UnwrapperTransformer(ast.NodeTransformer):
+    def visit_Name(self, node):
+        return unwrap_node(node.id)
+
+class EffectTransformer(ast.NodeTransformer):
+    def __init__(self):
+        super().__init__()
+
+    def visit_Return(self, node):
+        unwrapper = UnwrapperTransformer()
+        node.value = unwrapper.visit(node.value).body[0].value
+        return node
+
+    def visit_FunctionDef(self, node):
+        # Unwrap
+        node.body = [self.visit(node) for node in node.body]
+        print(ast.dump(node))
+        # Wrap args
+        args = node.args.args
+        args_id = map(lambda arg: arg.arg, args)
+        nodes = map(wrap_node, args_id)
+        for wrapper_node in nodes:
+            node.body.insert(0, wrapper_node)
+        return node
+
+def transform(node):
+    # Insert list wrapper code
+    with open("mrpython/effects/ListWrapper.py") as file:
+        code = file.read()
+        wrapper_node = ast.parse(code).body
+        node.body = wrapper_node + node.body
+    return node
+    
+if __name__ == '__main__':
+    effect = EffectTransformer()
+    with open("examples/list_add.py") as file:
+        node = ast.parse(file.read())
+        node = effect.visit(node)
+        node = transform(node)
+        code = astor.to_source(node)
+        print(code)
+        exec(code)


### PR DESCRIPTION
Hello,

Here is a POC for an effect checking system. It implements a `ListWrapper` around the list type.

Alterations to existing code are done demonstrated in `list_add.py`

I created an `effect` branch - as was said in the project description. Maybe it's best to create such a branch in nohtyprm's to avoid conflict with typechecking.

:hugs: