### PR TITLE
Fix cartesian power, debug output and shebang

### DIFF
--- a/examples/aire.py
+++ b/examples/aire.py
@@ -1,7 +1,7 @@
 import math
 
 def aire_triangle(a,b,c):
-    """ Number**3 -> float
+    """ Number ** 3 -> float
     Hypothèse : (a>0) and (b>0) and (c>0)
     Hypothèse : les côtés a, b et c définissent bien un triangle.
 

--- a/examples/poly.py
+++ b/examples/poly.py
@@ -1,6 +1,6 @@
 
 
 def poly(b,x):
-    """ Number^2 -> Number"""
+    """ Number ^ 2 -> Number"""
     return x**2(b)
 

--- a/mrpython.sh
+++ b/mrpython.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#!/bin/bash
 
 python3 ./mrpython/Application.py $*
 

--- a/mrpython/typechecking/prog_ast.py
+++ b/mrpython/typechecking/prog_ast.py
@@ -533,7 +533,7 @@ def parse_function(func_descr):
 class ECall(Expr):
     def __init__(self, node):
         self.ast = node
-        print(astpp.dump(node))
+        #print(astpp.dump(node))
 
         if isinstance(node.func, ast.Name):
             self.receiver = None

--- a/mrpython/typechecking/type_parser.py
+++ b/mrpython/typechecking/type_parser.py
@@ -261,10 +261,13 @@ def build_functype_grammar(grammar):
     
     dom_elem_parser = parsers.Tuple() \
                       .element(grammar.ref('typeexpr')) \
+                      .skip(grammar.ref('nspaces')) \
                       .element(parsers.Optional(parsers.Tuple() \
+                                                .skip(grammar.ref('spaces')) \
                                                 .element(parsers.Choice() \
-                                                         .either(parsers.Token('pow'))
+                                                         .either(parsers.Token('pow')) \
                                                          .orelse(parsers.Token('expr'))) \
+                                                .skip(grammar.ref('spaces')) \
                                                 .element(parsers.Token('natural'))))
 
     def dom_elem_xform_result(result):


### PR DESCRIPTION
This pull request basically did:
- add support for spaces between cartesian power and types.
- revert accidentally-enabled debug output in commit [7d57eaf](https://github.com/nohtyprm/MrPython/commit/7d57eaf021ec7b3d0f0b4120687d62feb63c5f17).
- modify shebang so that mypython.sh will work on major Linux distributions.