### PR TITLE
Workarounds for issue #17 and #58

### DIFF
--- a/mrpython/configHandler.py
+++ b/mrpython/configHandler.py
@@ -584,7 +584,7 @@ class MrPythonConf:
         keyBindings={
             '<<copy>>': ['<Control-c>', '<Control-C>'],
             '<<cut>>': ['<Control-x>', '<Control-X>'],
-            '<<paste>>': ['<Control-v>', '<Control-V>'],
+            # '<<paste>>': ['<Control-v>', '<Control-V>'],
             '<<beginning-of-line>>': ['<Control-a>', '<Home>'],
             '<<center-insert>>': ['<Control-l>'],
             '<<close-all-windows>>': ['<Control-q>'],


### PR DESCRIPTION
- Issue #17 
Tkinter supports copy & paste on native platforms, so there's no need to keep an outdated implementation keymapping Ctrl + V into a paste function. Experiments and previous issues show that texts are pasted twice on Windows and macOS. This fix simply commented out the old implementation, and might also solve the same problem under macOS.

- Issue #58 
This issue is important because it could lead to a misunderstanding of the real Python. Taking the example of Question 2 in Exercise 2.1, given on P17 of 1I001 Exercise Handbook, it's quite easy to see that the incorrect signature printed **Number -> str**ing will actually work in MrPython. A hackaround of this issue is given in this pull request, with no modification of popparser. 