### PR TITLE
fix: precondition in python 3.x are now working

### DIFF
--- a/mrpython/PreconditionLinenoHandler.py
+++ b/mrpython/PreconditionLinenoHandler.py
@@ -1,0 +1,16 @@
+import ast
+
+# This class is made to update precondition nodes to match them with
+# the right line
+# Not updating could mismatch traceback lineno with the expected precondition line
+class PreconditionAstLinenoUpdater(ast.NodeVisitor):
+
+    def __init__(self, lineno):
+        self.lineno = lineno
+
+    def visit(self, node):
+        if hasattr(node, 'lineno'):
+            node.lineno = self.lineno
+        if hasattr(node, 'end_lineno'):
+            node.end_lineno = self.lineno
+        self.generic_visit(node)


### PR DESCRIPTION
Unsupported precondition in python 3.11+ was caused by mismatching precondition lineno.

start_lineno > end_lineno in precondition ast was the main issue with the previous version.