### PR TITLE
Pstl2024 python311 bug

### DIFF
--- a/mrpython/PreconditionLinenoHandler.py
+++ b/mrpython/PreconditionLinenoHandler.py
@@ -1,0 +1,16 @@
+import ast
+
+# This class is made to update precondition nodes to match them with
+# the right line
+# Not updating could mismatch traceback lineno with the expected precondition line
+class PreconditionAstLinenoUpdater(ast.NodeVisitor):
+
+    def __init__(self, lineno):
+        self.lineno = lineno
+
+    def visit(self, node):
+        if hasattr(node, 'lineno'):
+            node.lineno = self.lineno
+        if hasattr(node, 'end_lineno'):
+            node.end_lineno = self.lineno
+        self.generic_visit(node)

--- a/mrpython/StudentRunner.py
+++ b/mrpython/StudentRunner.py
@@ -340,7 +340,7 @@ class FunctionDefVisitor(ast.NodeTransformer):
                 preconditionsLineno.append(lineno)
                 assert_node = ast.Assert(precondition_node)
                 assert_node.lineno = lineno + new_end_lineno
-                assert_node.end_lineno = assert_node.lineno + 1
+                assert_node.end_lineno = assert_node.lineno
                 ast_asserts.append(assert_node)
                 new_end_lineno += 1
             


### PR DESCRIPTION
Bug fix about preconditions support on Python 3.x
It was essentially due to node's lineno and end_lineno mismatch leading to incoherent state such as start_lineno > end_lineno